### PR TITLE
FIX: up Flask to 2.1.0

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,3 @@
 prometheus-client==0.11.0
 flask_prometheus_metrics==1.0.0
-Flask==1.1.1
+Flask==2.1.0


### PR DESCRIPTION
Hi! Thanks for this example-project of using python+prometheus+grafana. There is a small problem running a container named api1: `ImportError: cannot import name 'escape' from 'jinja2'`

Solution: https://stackoverflow.com/questions/71718167/importerror-cannot-import-name-escape-from-jinja2